### PR TITLE
Match on the recursively-processed pattern.

### DIFF
--- a/src/ppx_pattern_bind.ml
+++ b/src/ppx_pattern_bind.ml
@@ -33,7 +33,7 @@ let replace_variable ~f =
       method! pattern p =
         let pat = super#pattern p in
         let loc = p.ppat_loc in
-        match p.ppat_desc with
+        match pat.ppat_desc with
         | Ppat_var v ->
           (match f v with
            | `Rename tmpvar -> ppat_var ~loc { txt = tmpvar; loc = v.loc }


### PR DESCRIPTION
Signed-off-by: Nick Roberts <nroberts02@gmail.com>

Previously, nested as-patterns would fail to compile because the ppx would not use the recursively-processed pattern everywhere that it could.

Minimal buggy example:

```
open Base.Monad.Ident.Let_syntax

let _ = 
  match%pattern_bind () with
  | () as x as y -> ignore x; ignore y
```

Output pre-change (which notably is not a legal program, as x is not recursively renamed where we would expect it to be):

```
open Base.Monad.Ident.Let_syntax
let _ =
  let __pattern_syntax__001_ = () in
  Let_syntax.bind
    ((Let_syntax.map __pattern_syntax__001_ ~f:(function | () as x as y -> 0))
    [@ocaml.warning "-26-27"])
    ~f:(function
        | 0 ->
            let x =
              Let_syntax.map __pattern_syntax__001_
                ~f:(function | () as x -> __pattern_syntax_x)
            and y =
              Let_syntax.map __pattern_syntax__001_
                ~f:(function
                    | () as x as __pattern_syntax_y -> __pattern_syntax_y) in
            (ignore x; ignore y)
        | _ -> assert false)

```

Output post-change, where x is appropriately renamed (in the first pattern) and removed (in the second pattern):

```
open Base.Monad.Ident.Let_syntax
let _ =
  let __pattern_syntax__001_ = () in
  Let_syntax.bind
    ((Let_syntax.map __pattern_syntax__001_ ~f:(function | () as x as y -> 0))
    [@ocaml.warning "-26-27"])
    ~f:(function
        | 0 ->
            let x =
              Let_syntax.map __pattern_syntax__001_
                ~f:(function | () as __pattern_syntax_x -> __pattern_syntax_x)
            and y =
              Let_syntax.map __pattern_syntax__001_
                ~f:(function | () as __pattern_syntax_y -> __pattern_syntax_y) in
            (ignore x; ignore y)
        | _ -> assert false)
```